### PR TITLE
check_boot_jars: Whitelist lineage touch HAL

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -263,3 +263,7 @@ org\.codeaurora\.internal.*
 ###################################################
 # IFAA Manager used for Alipay and/or WeChat payment
 org\.ifaa\.android\.manager.*
+
+###################################################
+# Touch HAL
+vendor.lineage.touch.*


### PR DESCRIPTION
Solves the following on a dist target build:
Error: out/target/common/obj/JAVA_LIBRARIES/framework_intermediates/classes.jar contains class file vendor/lineage/touch/V1_0/ITouchscreenGesture.class, whose package name vendor.lineage.touch.V1_0 is not in the
whitelist build/make/core/tasks/check_boot_jars/package_whitelist.txt of packages allowed on the bootclasspath.

Signed-off-by: Anirudh Gupta <anirudhgupta109@gmail.com>
Signed-off-by: itsjoeoui <idkwhoiam@itsjoeoui.com>
Change-Id: I499fe217774476fd45d205c731520960b9c373f0
(cherry picked from commit 43a9fc5a248559c8236da94f15a0a59dc23143b1)